### PR TITLE
Check db after creation failure

### DIFF
--- a/spec/features/late_policy_creation_spec.rb
+++ b/spec/features/late_policy_creation_spec.rb
@@ -69,7 +69,10 @@ describe "Late Policy Creation" do
           :max_penalty => max_penalty,
         })
 
-      click_on "Create"
+      expect {
+        click_on "Create"
+      }.to_not change{LatePolicy.all.length}
+
       expect(page).to have_current_path(new_late_policy_path)
       expect(page).to have_content("Penalty per unit must be greater than 0")
     end


### PR DESCRIPTION
Check database table length to ensure failure of creation didn't create a new row